### PR TITLE
Cleanup bot_runner logging

### DIFF
--- a/tools/bot_runner/online_adapter.py
+++ b/tools/bot_runner/online_adapter.py
@@ -28,9 +28,9 @@ class OfflineAdapter:
         self._socket.close()
 
     def send(self, msg):
-        print(">>  {}\n".format(msg))
+        print(">>  {}\n".format(json.dumps(msg)))
         if self.log_file:
-            self.log_file.write(">> {}\n".format(msg))
+            self.log_file.write(">> {}\n".format(json.dumps(msg)))
         msg = format_as_message(msg)
         self._socket.send(msg)
         sleep(1.0)
@@ -53,7 +53,7 @@ class OfflineAdapter:
         msg = json.loads(msg_txt.split(':', 1)[1])
         print("<<  {}".format(json.dumps(msg)))
         if self.log_file:
-            self.log_file.write("<< {}\n".format(msg))
+            self.log_file.write("<< {}\n".format(json.dumps(msg)))
         return msg
 
     def run(self):


### PR DESCRIPTION
Remove the superfluous tuple in the output and add a newline to sent
messages. This provides a nice visual split between invocations of the
bot, which makes its logs easier to read.

e.g.,

```
<<  {"move": {"moves": [{"claim": {"source": 9, "punter": 0, "target": 28}}, {"claim": {"source": 11, "punter": 1, "target": 31}}, {"claim": {"source": 16, "punter": 2, "target": 21}}, {"pass": {"punter": 3}}]}}
I0805 10:42:59.401383   12600 main.go:45] Play
I0805 10:42:59.401957   12600 main.go:53] Turn: 1
>>  {u'pass': {u'punter': 3}}

<<  {"move": {"moves": [{"claim": {"source": 23, "punter": 0, "target": 27}}, {"claim": {"source": 3, "punter": 1, "target": 5}}, {"claim": {"source": 26, "punter": 2, "target": 27}}, {"pass": {"punter": 3}}]}}
I0805 10:43:00.425287   12605 main.go:45] Play
I0805 10:43:00.425897   12605 main.go:53] Turn: 2
>>  {u'pass': {u'punter': 3}}

<<  {"move": {"moves": [{"claim": {"source": 0, "punter": 0, "target": 7}}, {"claim": {"source": 5, "punter": 1, "target": 18}}, {"claim": {"source": 6, "punter": 2, "target": 36}}, {"pass": {"punter": 3}}]}}
I0805 10:43:01.444283   12610 main.go:45] Play
I0805 10:43:01.444527   12610 main.go:53] Turn: 3
>>  {u'pass': {u'punter': 3}}
```