### PR TITLE
Server

### DIFF
--- a/src/server/main.go
+++ b/src/server/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"bufio"
 )
 
 func loadMap(path string) (*protocol.Map, error) {
@@ -40,6 +41,7 @@ func main() {
 	options := flag.Bool("options", true, "to disable options use --options=false")
 	
 	runOnce := flag.Bool("runonce", false, "to run only one session use --runonce=true")
+	resultsFileName := flag.String("results", "results.log", "match results are appended to this file.")
 
 	flag.Parse()
 
@@ -56,6 +58,15 @@ func main() {
 	fmt.Printf("  Sites:  %d\n", len(mapData.Sites))
 	fmt.Printf("  Rivers: %d\n", len(mapData.Rivers))
 	fmt.Printf("  Mines:  %d\n", len(mapData.Mines))
+	
+	resultsFile, err := os.OpenFile(*resultsFileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE , 0600)
+	if err != nil {
+		panic(err)
+	}
+	defer resultsFile.Close()
+	
+	resultsWriter := bufio.NewWriter(resultsFile)
+	defer resultsWriter.Flush()
 
 	serv := Server{
 		Map:        *mapData,
@@ -69,5 +80,5 @@ func main() {
 		RunOnce: *runOnce,
 	}
 
-	serv.run()
+	serv.run(resultsWriter)
 }

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-	
 	"fmt"
 	"io"
 	"log"
@@ -329,7 +327,7 @@ type Server struct {
 	RunOnce    bool
 }
 
-func (s *Server) run() {
+func (s *Server) run(results *bufio.Writer) {
 	laddr := fmt.Sprintf(":%d", s.Port)
 
 	srv, err := net.Listen("tcp", laddr)
@@ -340,12 +338,6 @@ func (s *Server) run() {
 
 	fmt.Printf("-\n")
 	fmt.Printf("Listening at %s\n", laddr)
-
-	results, err := os.OpenFile("results.log", os.O_APPEND|os.O_WRONLY|os.O_CREATE , 0600)
-	if err != nil {
-		panic(err)
-	}
-	defer results.Close()
 	
 	for {
 		session := Session{
@@ -370,6 +362,7 @@ func (s *Server) run() {
 			results.WriteString(fmt.Sprintf("%s\n", name))
 			results.WriteString(fmt.Sprintf("%d\n", score.Score))
 		}
+		results.Flush()
 		
 		if s.RunOnce {
 			return


### PR DESCRIPTION
Added support for Options and Splurges.  Enabled by default, disable with:
--options=false
--splurges=false

Added logging of results.  Default ./results.log

Added runonce option.  Disabled by default.  Enable with:
--runone=true

Considerable refactorization.